### PR TITLE
Add statx

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,6 @@ edition = "2018"
 num_cpus = "1.13.0"
 indicatif = "0.14.0"
 clap = { version = "4.0.29", features = ["derive"] }
-statx-sys = "0.4.1"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+rustix = { version = "0.36.6", features = ["fs"] }

--- a/src/csv.rs
+++ b/src/csv.rs
@@ -3,10 +3,10 @@ use std::io::BufRead;
 use std::io::BufReader;
 use std::io::Write;
 
-use super::objects;
+use crate::objects;
 
-static OUTPUT_FILE: &'static str = "fs-scan_output.csv";
-static FILE_FIRST_LINE: &'static str = "Path,Duration_ms,Files,Directories,Empty_files,Less_than_4K,4K_8K,8K_16K,16K_32K,32K_64K,64K_128K,128K_256K,256K_512K,512K_1M,1M_10M,10M_100M,100M_1G,1G";
+static OUTPUT_FILE: &str = "fs-scan_output.csv";
+static FILE_FIRST_LINE: &str = "Path,Duration_ms,Files,Directories,Empty_files,Less_than_4K,4K_8K,8K_16K,16K_32K,32K_64K,64K_128K,128K_256K,256K_512K,512K_1M,1M_10M,10M_100M,100M_1G,1G";
 
 pub fn save(res: &objects::Result) {
     match check_file() {
@@ -20,12 +20,10 @@ pub fn save(res: &objects::Result) {
     let mut file = OpenOptions::new()
         .write(true)
         .append(true)
-        .open(&OUTPUT_FILE)
+        .open(OUTPUT_FILE)
         .unwrap();
 
-    if let Err(_) = writeln!(file, "{}", res.csv_line()) {
-        return;
-    }
+    let _ = writeln!(file, "{}", res.csv_line());
 }
 
 fn check_file() -> Result<String, String> {
@@ -33,7 +31,7 @@ fn check_file() -> Result<String, String> {
     let mut file = match OpenOptions::new()
         .read(true)
         .write(true)
-        .open(&OUTPUT_FILE)
+        .open(OUTPUT_FILE)
     {
         Err(_) => {
             // File not opened
@@ -43,7 +41,7 @@ fn check_file() -> Result<String, String> {
                 .read(true)
                 .append(true)
                 .create(true)
-                .open(&OUTPUT_FILE)
+                .open(OUTPUT_FILE)
             {
                 Err(_) => return Err("can't open/create new file".to_string()),
                 Ok(file) => file,
@@ -56,7 +54,7 @@ fn check_file() -> Result<String, String> {
     match file.metadata() {
         Ok(m) => {
             if m.len() == 0 {
-                if let Err(_) = writeln!(&mut file, "{}", &String::from(FILE_FIRST_LINE)) {
+                if writeln!(&mut file, "{}", &String::from(FILE_FIRST_LINE)).is_err() {
                     return Err("can't write first line".to_string());
                 }
                 return Ok("new file created and first line added successfully".to_string());
@@ -69,16 +67,14 @@ fn check_file() -> Result<String, String> {
     //
     // Read the content
     let file_content = BufReader::new(&file);
-    for line in file_content.lines() {
-        // let l = line.unwrap();
+    if let Some(line) = file_content.lines().next() {
         let l = match line {
             Ok(l) => l,
             Err(e) => return Err(format!("can't read line: {}", e)),
         };
-        if l == FILE_FIRST_LINE {
-            break;
+        if l != FILE_FIRST_LINE {
+            return Err(format!("Not the same line: content {}", l));
         }
-        return Err(format!("Not the same line: content {}", l));
     }
 
     Ok("first line valid, can add the new report".to_string())

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ fn main() {
     // Stop execution if feature requested
     if conf.lustre_lsom {
         println!("Lustre LSoM feature is not yet implemented");
-        return;
+        // return;
     }
 
     if conf.max_threads == 0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,12 +12,6 @@ use num_cpus;
 fn main() {
     let mut conf = objects::Config::parse();
 
-    // Stop execution if feature requested
-    if conf.lustre_lsom {
-        println!("Lustre LSoM feature is not yet implemented");
-        // return;
-    }
-
     if conf.max_threads == 0 {
         conf.max_threads = num_cpus::get() * 4;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,6 @@ use std::time;
 
 use clap::Parser;
 use indicatif::{HumanDuration, ProgressBar, ProgressStyle};
-use num_cpus;
 
 fn main() {
     let mut conf = objects::Config::parse();
@@ -31,7 +30,7 @@ fn main() {
     // Start scanning at the given path
     conf.handle_dir(PathBuf::from(&conf.path), sender.clone(), &bar);
 
-    let cloned_sender_again = sender.clone();
+    let cloned_sender_again = sender;
     let mut running_thread = 0;
     let mut dir_queue = Vec::new();
 
@@ -39,7 +38,7 @@ fn main() {
 
     let display_refresh_time = time::Duration::from_millis(250);
     let mut last_message = time::Instant::now()
-        .checked_sub(display_refresh_time.clone())
+        .checked_sub(display_refresh_time)
         .expect("to remove some time");
 
     // Handle responses
@@ -111,13 +110,12 @@ fn main() {
         csv::save(&res);
     }
 
-    let duration_to_display;
     let ms_dur = res.duration.as_millis();
-    if ms_dur < 1000 {
-        duration_to_display = ms_dur.to_string() + "ms";
+    let duration_to_display = if ms_dur < 1000 {
+        ms_dur.to_string() + "ms"
     } else {
-        duration_to_display = HumanDuration(res.duration).to_string();
-    }
+        HumanDuration(res.duration).to_string()
+    };
     println!("Scan took {duration_to_display}");
 
     println!("Files -> {}", nice_number(res.files));
@@ -173,43 +171,43 @@ fn main() {
 
 fn nice_number(input: usize) -> String {
     if input < 1_000 {
-        return format!("{:?}", input);
+        format!("{:?}", input)
     } else if input < 1_000_000 {
-        return format!("{:?}K ({:?})", input / 1_000, input);
+        format!("{:?}K ({:?})", input / 1_000, input)
     } else {
-        return format!("{:?}M ({:?})", input / 1_000_000, input);
+        format!("{:?}M ({:?})", input / 1_000_000, input)
     }
 }
 
 fn handle_file(len: u64, res: &mut objects::Result) {
     if len == 0 {
-        res.empty_file = res.empty_file + 1;
+        res.empty_file += 1;
     } else if len < 4_000 {
-        res.less_than_4_k = res.less_than_4_k + 1;
+        res.less_than_4_k += 1;
     } else if len < 8_000 {
-        res.between_4_k_8_k = res.between_4_k_8_k + 1;
+        res.between_4_k_8_k += 1;
     } else if len < 16_000 {
-        res.between_8_k_16_k = res.between_8_k_16_k + 1;
+        res.between_8_k_16_k += 1;
     } else if len < 32_000 {
-        res.between_16_k_32_k = res.between_16_k_32_k + 1;
+        res.between_16_k_32_k += 1;
     } else if len < 64_000 {
-        res.between_32_k_64_k = res.between_32_k_64_k + 1;
+        res.between_32_k_64_k += 1;
     } else if len < 128_000 {
-        res.between_64_k_128_k = res.between_64_k_128_k + 1;
+        res.between_64_k_128_k += 1;
     } else if len < 256_000 {
-        res.between_128_k_256_k = res.between_128_k_256_k + 1;
+        res.between_128_k_256_k += 1;
     } else if len < 512_000 {
-        res.between_256_k_512_k = res.between_256_k_512_k + 1;
+        res.between_256_k_512_k += 1;
     } else if len < 1_000_000 {
-        res.between_512_k_1_m = res.between_512_k_1_m + 1;
+        res.between_512_k_1_m += 1;
     } else if len < 10_000_000 {
-        res.between_1_m_10_m = res.between_1_m_10_m + 1;
+        res.between_1_m_10_m += 1;
     } else if len < 100_000_000 {
-        res.between_10_m_100_m = res.between_10_m_100_m + 1;
+        res.between_10_m_100_m += 1;
     } else if len < 1_000_000_000 {
-        res.between_100_m_1_g = res.between_100_m_1_g + 1;
+        res.between_100_m_1_g += 1;
     } else {
-        res.more_than_1_g = res.more_than_1_g + 1;
+        res.more_than_1_g += 1;
     }
-    res.files = res.files + 1;
+    res.files += 1;
 }

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -200,8 +200,8 @@ fn handle_file_stat(
         let stat = statx(
             dir,
             file_c_str.clone(),
-            AtFlags::SYMLINK_NOFOLLOW,
-            StatxFlags::TYPE,
+            AtFlags::SYMLINK_NOFOLLOW | AtFlags::STATX_DONT_SYNC,
+            StatxFlags::SIZE,
         )
         .unwrap_or_else(|_| {
             panic!(


### PR DESCRIPTION
Use `statx` syscall. Only used on linux architecture and disabled for other target.

Also fixed some clippy warning/error.

From my testing, performance gain is close to 0 but I guess it depends on datasets and FS activity.

Should address #2. 
```
[root@localhost client]# echo 3 > /proc/sys/vm/drop_caches && time ./fs-scan -l ./generated_data/
2m ####################  80/80  Total file scanned 764221
Scan took 2 minutes
Files -> 764K (764221)
Directories -> 17
Empty files -> 2
Less than 4K -> 29K (29846)
Between 4KB and 8KB -> 3K (3386)
Between 8KB and 16KB -> 5K (5411)
Between 16KB and 32KB -> 12K (12596)
Between 32KB and 64KB -> 87K (87960)
Between 64KB and 128KB -> 383K (383710)
Between 128KB and 256KB -> 241K (241310)
Between 256KB and 512KB -> 0
Between 512KB and 1MB -> 0
Between 1MB and 10MB -> 0
Between 10MB and 100MB -> 0
Between 100MB and 1GB -> 0
More than 1GB -> 0

real    1m48.728s
user    0m4.962s
sys     1m21.014s
[root@localhost client]# echo 3 > /proc/sys/vm/drop_caches && time ./fs-scan ./generated_data/
2m ####################  80/80  Total file scanned 764221
Scan took 2 minutes
Files -> 764K (764221)
Directories -> 17
Empty files -> 2
Less than 4K -> 29K (29846)
Between 4KB and 8KB -> 3K (3386)
Between 8KB and 16KB -> 5K (5411)
Between 16KB and 32KB -> 12K (12596)
Between 32KB and 64KB -> 87K (87960)
Between 64KB and 128KB -> 383K (383710)
Between 128KB and 256KB -> 241K (241310)
Between 256KB and 512KB -> 0
Between 512KB and 1MB -> 0
Between 1MB and 10MB -> 0
Between 10MB and 100MB -> 0
Between 100MB and 1GB -> 0
More than 1GB -> 0

real    1m41.925s
user    0m3.855s
sys     1m9.626s
```